### PR TITLE
fix: Add Footnotes section to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Organizations](#organizations)
 - [Education](#education)
 - [Standards](#standards)
+- [Footnotes](#footnotes)
 
 ## Tools
 


### PR DESCRIPTION
The footnotes heading was missing in TOC. 
If that was intentional, then feel free to close.
